### PR TITLE
Feat/ci-tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,26 @@
+name: CI - Run Tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test -- --watchAll=false

--- a/src/components/atoms/Card/Card.styles.tsx
+++ b/src/components/atoms/Card/Card.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 import { Paper } from "../Paper/Paper";
+import { PaperType } from "../Paper/Paper.styles";
 
 export type CardType = {
   transition?: string;
@@ -20,7 +21,7 @@ export type CardType = {
 
   children: React.ReactNode;
   onClick?: () => void;
-};
+} & PaperType;
 
 export const StyledCard = styled(Paper).withConfig({
   shouldForwardProp: (prop) =>

--- a/src/components/atoms/Card/Card.test.tsx
+++ b/src/components/atoms/Card/Card.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { CardType, StyledCard } from "./Card.styles";
+
+const renderComponent = (props?: Partial<CardType>) =>
+  render(<StyledCard {...props}>Card Content</StyledCard>);
+
+describe("<Card />", () => {
+  test("renders with default styles", () => {
+    renderComponent();
+    const card = screen.getByText("Card Content");
+
+    expect(card).toHaveStyle({
+      display: "block",
+      flexDirection: "",
+      justifyContent: "",
+      alignItems: "",
+      gap: "",
+      gridTemplateColumns: "",
+      gridTemplateRows: "",
+      gridColumn: "",
+      gridRow: "",
+      transition: "",
+      cursor: "pointer",
+    });
+  });
+
+  test("renders with custom flex styles", () => {
+    renderComponent({
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "center",
+      alignItems: "flex-start",
+      gap: "10px",
+    });
+
+    const card = screen.getByText("Card Content");
+    const computedStyles = window.getComputedStyle(card);
+
+    expect(computedStyles.display).toBe("flex");
+    expect(computedStyles.flexDirection).toBe("row");
+    expect(computedStyles.justifyContent).toBe("center");
+    expect(computedStyles.alignItems).toBe("flex-start");
+    expect(computedStyles.gap).toBe("10px");
+  });
+
+  test("renders with custom grid styles", () => {
+    renderComponent({
+      display: "grid",
+      gridTemplateColumns: "repeat(2, 1fr)",
+      gridTemplateRows: "auto",
+      gridColumn: "1 / span 2",
+      gridRow: "2 / span 3",
+    });
+
+    const card = screen.getByText("Card Content");
+    const computedStyles = window.getComputedStyle(card);
+
+    expect(computedStyles.display).toBe("grid");
+    expect(computedStyles.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(computedStyles.gridTemplateRows).toBe("auto");
+
+    const normalizeGridValue = (value: string) => value.replace(/\s+/g, "");
+
+    expect(normalizeGridValue(computedStyles.gridColumn)).toBe("1/span2");
+    expect(normalizeGridValue(computedStyles.gridRow)).toBe("2/span3");
+  });
+
+  test("applies transition effect", () => {
+    renderComponent({ transition: "all 0.3s ease-in-out" });
+
+    const card = screen.getByText("Card Content");
+
+    expect(card).toHaveStyle({
+      transition: "all 0.3s ease-in-out",
+    });
+  });
+
+  test("renders with hover styles when withHover is true", () => {
+    renderComponent({
+      withHover: true,
+      hoverBoxShadow: "0px 4px 10px rgba(0,0,0,0.2)",
+      hoverTransform: "scale(1.05)",
+    });
+
+    const card = screen.getByText("Card Content");
+
+    fireEvent.mouseOver(card);
+
+    const computedStyles = window.getComputedStyle(card);
+
+    expect(computedStyles.transform).toBe("scale(1.05)");
+    expect(computedStyles.boxShadow).toBe("0px 4px 10px rgba(0,0,0,0.2)");
+  });
+
+  test("calls onClick function when clicked", () => {
+    const handleClick = jest.fn();
+    renderComponent({ onClick: handleClick });
+
+    const card = screen.getByText("Card Content");
+    card.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/atoms/ListItem/ListItem.test.tsx
+++ b/src/components/atoms/ListItem/ListItem.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { StyledListItem, StyledListItemType } from "./ListItem.styles";
+
+const renderComponent = (props?: Partial<StyledListItemType>) =>
+  render(<StyledListItem {...props}>List Item</StyledListItem>);
+
+describe("<StyledListItem />", () => {
+  test("renders with default styles", () => {
+    renderComponent();
+    const listItem = screen.getByText("List Item");
+
+    expect(listItem).toBeInTheDocument();
+    expect(listItem).toHaveStyle({
+      display: "list-item",
+      listStyle: "none",
+      margin: "0",
+      padding: "0",
+    });
+  });
+
+  test("renders with custom margin and padding", () => {
+    renderComponent({
+      margin: "10px",
+      padding: "5px",
+    });
+
+    const listItem = screen.getByText("List Item");
+    const computedStyles = window.getComputedStyle(listItem);
+
+    expect(computedStyles.margin).toBe("10px");
+    expect(computedStyles.padding).toBe("5px");
+  });
+
+  test("renders as an <li> element", () => {
+    renderComponent();
+    const listItem = screen.getByText("List Item");
+
+    expect(listItem.tagName).toBe("LI");
+  });
+});

--- a/src/components/atoms/Paper/Paper.styles.tsx
+++ b/src/components/atoms/Paper/Paper.styles.tsx
@@ -49,6 +49,7 @@ export const StyledPaper = styled.div.withConfig({
   border-radius: ${({ borderRadius }) => borderRadius || ""};
   box-shadow: ${({ boxShadow }) => boxShadow || ""};
   padding: ${({ padding }) => padding || "0"};
+  margin: ${({ margin }) => margin || ""};
   width: ${({ width }) => width || "100%"};
   height: ${({ height }) => height || "auto"};
 

--- a/src/components/atoms/Paper/Paper.test.tsx
+++ b/src/components/atoms/Paper/Paper.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { PaperType, StyledPaper } from "./Paper.styles";
+
+const renderComponent = (props?: Partial<PaperType>) =>
+  render(<StyledPaper {...props}>Paper Content</StyledPaper>);
+
+describe("<StyledPaper />", () => {
+  test("renders with default styles", () => {
+    renderComponent();
+    const paper = screen.getByText("Paper Content");
+
+    expect(paper).toBeInTheDocument();
+    expect(paper).toHaveStyle({
+      display: "block",
+      width: "100%",
+      height: "auto",
+      padding: "0",
+    });
+  });
+
+  test("renders with custom styles", () => {
+    renderComponent({
+      display: "flex",
+      position: "absolute",
+      inset: "10px",
+      zIndex: 5,
+      background: "blue",
+      border: "1px solid black",
+      borderRadius: "8px",
+      boxShadow: "2px 2px 10px rgba(0, 0, 0, 0.5)",
+      padding: "20px",
+      margin: "15px",
+      width: "200px",
+      height: "150px",
+    });
+
+    const paper = screen.getByText("Paper Content");
+    const computedStyles = window.getComputedStyle(paper);
+
+    expect(computedStyles.display).toBe("flex");
+    expect(computedStyles.position).toBe("absolute");
+    expect(computedStyles.inset).toBe("10px");
+    expect(computedStyles.zIndex).toBe("5");
+    expect(computedStyles.backgroundColor).toBe("blue");
+    expect(computedStyles.border).toBe("1px solid black");
+    expect(computedStyles.borderRadius).toBe("8px");
+    expect(computedStyles.boxShadow).toBe("2px 2px 10px rgba(0, 0, 0, 0.5)");
+    expect(computedStyles.padding).toBe("20px");
+    expect(computedStyles.margin).toBe("15px");
+    expect(computedStyles.width).toBe("200px");
+    expect(computedStyles.height).toBe("150px");
+  });
+
+  test("applies hover styles when withHover is true", () => {
+    renderComponent({
+      withHover: true,
+      hoverBackground: "red",
+      hoverBoxShadow: "4px 4px 15px rgba(0, 0, 0, 0.3)",
+      hoverTransform: "scale(1.1)",
+    });
+
+    const paper = screen.getByText("Paper Content");
+
+    fireEvent.mouseOver(paper);
+
+    const computedStyles = window.getComputedStyle(paper);
+
+    expect(computedStyles.backgroundColor).toBe("red");
+    expect(computedStyles.boxShadow).toBe("4px 4px 15px rgba(0, 0, 0, 0.3)");
+    expect(computedStyles.transform).toBe("scale(1.1)");
+  });
+});

--- a/src/components/atoms/SectionHeader/SectionHeader.test.tsx
+++ b/src/components/atoms/SectionHeader/SectionHeader.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import "jest-styled-components";
+import { ThemeProvider } from "styled-components";
+
+import { lightTheme } from "@styles";
+
+import { SectionHeader, SectionHeaderProps } from "./SectionHeader";
+
+const renderComponent = (props?: Partial<SectionHeaderProps>) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <SectionHeader
+        ariaLabel={props?.ariaLabel || "section-header"}
+        title={props?.title}
+      />
+    </ThemeProvider>
+  );
+
+describe("<SectionHeader />", () => {
+  test("renders correctly with default styles", () => {
+    renderComponent();
+    const header = screen.getByLabelText("section-header");
+
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveStyle({
+      opacity: "0.5",
+      textTransform: "uppercase",
+      zIndex: "10",
+    });
+  });
+
+  test("renders with provided title", () => {
+    renderComponent({ title: "Test Title" });
+    const header = screen.getByText("Test Title");
+
+    expect(header).toBeInTheDocument();
+  });
+
+  test("applies the correct aria-label for accessibility", () => {
+    renderComponent({ ariaLabel: "custom-header-label" });
+    const header = screen.getByLabelText("custom-header-label");
+
+    expect(header).toBeInTheDocument();
+  });
+
+  test("renders as a <header> element", () => {
+    renderComponent();
+    const header = screen.getByLabelText("section-header");
+
+    expect(header.tagName).toBe("HEADER");
+  });
+});

--- a/src/components/atoms/Tag/Tag.test.tsx
+++ b/src/components/atoms/Tag/Tag.test.tsx
@@ -1,0 +1,73 @@
+import { screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { lightTheme } from "@styles";
+
+import { Tag } from "./Tag";
+import { hexToRgba, renderWithTheme } from "src/utils/test-utils";
+
+describe("<Tag />", () => {
+  test("renders correctly with default theme styles", () => {
+    renderWithTheme(<Tag text="Default Tag" aria-label="tag-label" />);
+    const tag = screen.getByText("Default Tag");
+    const computedStyles = window.getComputedStyle(tag);
+
+    expect(tag).toBeInTheDocument();
+    expect(computedStyles.display).toBe("flex");
+    expect(computedStyles.alignItems).toBe("center");
+    expect(computedStyles.borderRadius).toBe("9999px");
+    expect(computedStyles.padding).toBe(
+      `${lightTheme.spacing.xxs} ${lightTheme.spacing.xs}`
+    );
+    expect(computedStyles.backgroundColor).toBe(
+      hexToRgba(lightTheme.backgroundTag)
+    );
+    expect(computedStyles.color).toBe(hexToRgba(lightTheme.textTertiary));
+    expect(computedStyles.lineHeight).toBe(lightTheme.lineHeight.sm);
+    expect(computedStyles.fontWeight).toBe(lightTheme.fontWeight.semiBold);
+    expect(computedStyles.fontSize).toBe(lightTheme.fontSize.small);
+  });
+
+  test("renders with custom styles", () => {
+    renderWithTheme(
+      <Tag
+        text="Styled Tag"
+        color="white"
+        backgroundColor="blue"
+        padding="8px 12px"
+        borderRadius="4px"
+        fontSize="14px"
+        fontWeight="bold"
+        lineHeight="1.2"
+      />
+    );
+
+    const tag = screen.getByText("Styled Tag");
+    const computedStyles = window.getComputedStyle(tag);
+
+    expect(computedStyles.color).toBe("white");
+    expect(computedStyles.backgroundColor).toBe("blue");
+    expect(computedStyles.padding).toBe("8px 12px");
+    expect(computedStyles.borderRadius).toBe("4px");
+    expect(computedStyles.fontSize).toBe("14px");
+    expect(computedStyles.fontWeight).toBe("bold");
+    expect(computedStyles.lineHeight).toBe("1.2");
+  });
+
+  test("calls onClick handler when clicked", () => {
+    const handleClick = jest.fn();
+    renderWithTheme(<Tag text="Clickable Tag" onClick={handleClick} />);
+    const tag = screen.getByText("Clickable Tag");
+
+    fireEvent.click(tag);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders as a <span> element", () => {
+    renderWithTheme(<Tag text="Tag Element" />);
+    const tag = screen.getByText("Tag Element");
+
+    expect(tag.tagName).toBe("SPAN");
+  });
+});

--- a/src/components/atoms/Typography/Typography.test.tsx
+++ b/src/components/atoms/Typography/Typography.test.tsx
@@ -3,7 +3,6 @@ import "@testing-library/jest-dom";
 
 import { TypographyType } from "./Typography.styles";
 import { Typography } from "./Typography";
-import { text } from "stream/consumers";
 
 const renderComponent = (props?: Partial<TypographyType>) =>
   render(<Typography {...props}>Typography Content</Typography>);
@@ -72,7 +71,6 @@ describe("<Typography />", () => {
     renderComponent({ as: "h1" });
     const typo = screen.getByText("Typography Content");
 
-    // Assert the rendered tag is 'h1'
     expect(typo.tagName).toBe("H1");
   });
 });

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+
+import { lightTheme } from "@styles";
+
+export const renderWithTheme = (ui: React.ReactElement, theme = lightTheme) => {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+export const hexToRgba = (hex: string) => {
+  const hexCode = hex.replace("#", "");
+  const r = parseInt(hexCode.substring(0, 2), 16);
+  const g = parseInt(hexCode.substring(2, 4), 16);
+  const b = parseInt(hexCode.substring(4, 6), 16);
+  const a =
+    hexCode.length === 8
+      ? Math.round((parseInt(hexCode.substring(6, 8), 16) / 255) * 1000) / 1000
+      : 1;
+
+  return a === 1 ? `rgb(${r}, ${g}, ${b})` : `rgba(${r}, ${g}, ${b}, ${a})`;
+};


### PR DESCRIPTION
- Added CI Workflow 
- Added tests for the following atom components: Tag, SectionHeader, ListItem, Paper, Card
- Created a reusable test utility (test-utils.tsx) for rendering components with themes.
- Fixed Jest style-related assertions (color comparison using hex conversion).



TESTS:
![Screenshot 2025-02-07 at 15 48 51](https://github.com/user-attachments/assets/0f25398e-b54a-4398-862a-231c5376f137)
